### PR TITLE
Support for new Sophia syntax

### DIFF
--- a/examples/Example.aes
+++ b/examples/Example.aes
@@ -1,0 +1,18 @@
+namespace Nsp =
+  function f() = ()
+
+contract interface I =
+  entrypoint f : () => int
+
+contract C =
+  using Nsp
+  using Nsp as N
+  using Nsp for [f]
+  using Nsp hiding [f]
+  using Nsp as N for [f]
+  using Nsp as N hiding [f]
+
+  entrypoint init() = ()
+
+main contract Main =
+  entrypoint init() = ()

--- a/syntaxes/sophia.json
+++ b/syntaxes/sophia.json
@@ -310,7 +310,7 @@
                     "name": "keyword.control.exceptions.sophia"
                 },
                 {
-                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|using|as|for|hiding|main)\\b",
+                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|main)\\b",
                     "name": "keyword.control.keywords.sophia"
                 },
                 {

--- a/syntaxes/sophia.json
+++ b/syntaxes/sophia.json
@@ -310,7 +310,7 @@
                     "name": "keyword.control.exceptions.sophia"
                 },
                 {
-                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|using|as|for|hiding)\\b",
+                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|using|as|for|hiding|main)\\b",
                     "name": "keyword.control.keywords.sophia"
                 },
                 {

--- a/syntaxes/sophia.json
+++ b/syntaxes/sophia.json
@@ -310,7 +310,7 @@
                     "name": "keyword.control.exceptions.sophia"
                 },
                 {
-                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype)\\b",
+                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|using|as|for|hiding)\\b",
                     "name": "keyword.control.keywords.sophia"
                 },
                 {

--- a/syntaxes/sophia.json
+++ b/syntaxes/sophia.json
@@ -313,7 +313,7 @@
                     "name": "keyword.control.exceptions.sophia"
                 },
                 {
-                    "match": "\\b(and|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|main)\\b",
+                    "match": "\\b(and|elif|else|false|function|if|import|include|internal|let|mod|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|main)\\b",
                     "name": "keyword.control.keywords.sophia"
                 },
                 {
@@ -388,10 +388,10 @@
             }
         },
         "declaration-namespace": {
-            "match": "\\b(namespace)(\\s+([A-Za-z_]\\w*))?\\b",
+            "match": "\\b(namespace)(\\s+([A-Z]\\w*))?\\b",
             "captures": {
                 "1": {
-                    "name": "storage.type.namespace.sophia"
+                    "name": "keyword.control.keywords.sophia"
                 },
                 "3": {
                     "name": "entity.name.type.namespace.sophia"

--- a/syntaxes/sophia.json
+++ b/syntaxes/sophia.json
@@ -39,6 +39,9 @@
         },
         {
             "include": "#punctuation"
+        },
+        {
+            "include": "#alias"
         }
     ],
     "repository": {
@@ -483,6 +486,30 @@
                 {
                     "match": ",",
                     "name": "punctuation.separator.sophia"
+                }
+            ]
+        },
+        "alias": {
+            "patterns": [
+                {
+                    "match": "(using)\\s+([A-Za-z_']*)(\\s+(as)\\s+([A-Za-z_']*))?(\\s+(for|hiding))?",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.control.keywords.sophia"
+                        },
+                        "2": {
+                            "name": "entity.name.namespace.sophia"
+                        },
+                        "4": {
+                            "name": "keyword.control.keywords.sophia"
+                        },
+                        "5": {
+                            "name": "entity.name.namespace.sophia"
+                        },
+                        "7": {
+                            "name": "keyword.control.keywords.sophia"
+                        }
+                    }
                 }
             ]
         }

--- a/syntaxes/sophia.json
+++ b/syntaxes/sophia.json
@@ -313,7 +313,7 @@
                     "name": "keyword.control.exceptions.sophia"
                 },
                 {
-                    "match": "\\b(and|contract|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|main)\\b",
+                    "match": "\\b(and|elif|else|false|function|if|import|include|internal|let|mod|namespace|private|public|rec|payable|stateful|entrypoint|switch|true|type|record|datatype|main)\\b",
                     "name": "keyword.control.keywords.sophia"
                 },
                 {
@@ -330,9 +330,6 @@
             "patterns": [
                 {
                     "include": "#declaration-contract"
-                },
-                {
-                    "include": "#declaration-interface"
                 },
                 {
                     "include": "#declaration-library"
@@ -360,12 +357,15 @@
         "declaration-contract": {
             "patterns": [
                 {
-                    "match": "\\b(contract)(\\s+([A-Za-z_]\\w*))?\\b",
+                    "match": "\\b(contract)(\\s+interface)?(\\s+([A-Z]\\w*))?\\b",
                     "captures": {
                         "1": {
-                            "name": "storage.type.contract.sophia"
+                            "name": "keyword.control.keywords.sophia"
                         },
-                        "3": {
+                        "2": {
+                            "name": "keyword.control.keywords.sophia"
+                        },
+                        "4": {
                             "name": "entity.name.type.contract.sophia"
                         }
                     }
@@ -375,17 +375,6 @@
                     "name": "storage.modifier.is.sophia"
                 }
             ]
-        },
-        "declaration-interface": {
-            "match": "\\b(interface)(\\s+([A-Za-z_]\\w*))?\\b",
-            "captures": {
-                "1": {
-                    "name": "storage.type.interface.sophia"
-                },
-                "3": {
-                    "name": "entity.name.type.interface.sophia"
-                }
-            }
         },
         "declaration-library": {
             "match": "\\b(library)(\\s+([A-Za-z_]\\w*))?\\b",


### PR DESCRIPTION
This PR includes support for:
- The `main` keyword for main contracts.
- The `using` statement.
- The new contract interface syntax.